### PR TITLE
chore(name): Change package name to "cordless"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,4 @@
 
 ### Features
 
-* add base functionality ([b533cce](https://github.com/TomerRon/disco-bot/commit/b533cce2933d7687b03ed635e0717b4a4722512c))
+* add base functionality ([b533cce](https://github.com/TomerRon/cordless/commit/b533cce2933d7687b03ed635e0717b4a4722512c))

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-<h1 align="center" style="border-bottom: none;">💃🤖 disco-bot</h1>
+<h1 align="center" style="border-bottom: none;">🤖 cordless</h1>
 <h3 align="center">Opinionated framework for creating Discord bots with minimal boilerplate</h3>
 
-**disco-bot** is a simple wrapper for [discord.js](https://github.com/discordjs/discord.js) that allows you to create extensive and extensible Discord bots.
+**cordless** is a simple wrapper for [discord.js](https://github.com/discordjs/discord.js) that allows you to create extensive and extensible Discord bots.
 
 ```
-yarn add disco-bot
-npm i disco-bot
+yarn add cordless
+npm i cordless
 ```
 
 ## Basic Usage
 
 ```ts
-import { init, BotFunction } from 'disco-bot'
+import { init, BotFunction } from 'cordless'
 
 const ping: BotFunction = {
   condition: (msg) => msg.content === 'ping',
@@ -26,8 +26,8 @@ init({ functions: [ping] }).login(process.env.TOKEN)
 Clone and install the dependencies:
 
 ```
-git clone https://github.com/TomerRon/disco-bot.git
-cd disco-bot
+git clone https://github.com/TomerRon/cordless.git
+cd cordless
 yarn
 ```
 
@@ -47,7 +47,7 @@ yalc publish
 You can then test your changes in a local app using:
 
 ```
-yalc add disco-bot
+yalc add cordless
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "disco-bot",
+  "name": "cordless",
   "version": "1.0.0",
   "author": "Tomer Ron",
   "repository": {
     "type": "git",
-    "url": "https://github.com/TomerRon/disco-bot.git"
+    "url": "https://github.com/TomerRon/cordless.git"
   },
   "license": "ISC",
   "private": false,

--- a/src/init.ts
+++ b/src/init.ts
@@ -2,7 +2,7 @@ import Discord from 'discord.js'
 import { InitOptions } from './types'
 
 /**
- * Initializes disco-bot with the given options.
+ * Initializes a cordless bot with the given options.
  * Returns a discord.js client.
  */
 export const init = (options: InitOptions): Discord.Client => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import Discord from 'discord.js'
 
-/** Initialization options for disco-bot */
+/** Initialization options for your cordless bot */
 export type InitOptions = {
   /** The functions used by your bot */
   functions: BotFunction[]


### PR DESCRIPTION
This PR changes the package name to `cordless`.

The previous name, `disco-bot`, was rejected by NPM as it was too similar to an existing package.