### PR TITLE
feat(help): Add built-in help function

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,7 +13,7 @@
   ],
   "rules": {
     "arrow-body-style": [2, "as-needed"],
-    "indent": [2, 2],
+    "indent": [0],
     "import/no-unresolved": "off",
     "padding-line-between-statements": [
       2,

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ npm i cordless
 
 ## Basic Usage
 
+Follow [this guide](https://discordjs.guide/preparations/setting-up-a-bot-application.html#creating-your-bot) to create a Discord bot in the Discord developer portal.
+
+TypeScript:
+
 ```ts
 import { init, BotFunction } from 'cordless'
 
@@ -30,10 +34,80 @@ const ping: BotFunction = {
   callback: (msg) => msg.reply('pong'),
 }
 
-init({ functions: [ping] }).login(process.env.TOKEN)
+init({ functions: [ping] }).login('your.bot.token')
 ```
 
-## Contributing
+JavaScript:
+
+```js
+const cordless = require('cordless')
+
+const ping = {
+  condition: (msg) => msg.content === 'ping',
+  callback: (msg) => msg.reply('pong'),
+}
+
+cordless.init({ functions: [ping] }).login('your.bot.token')
+```
+
+## Advanced Usage
+
+### Automatic documentation
+
+Auto-generate a help function for your bot by passing a `helpCommand`.
+Make sure you give your functions a name and description if you want to use them with the generated help function.
+
+For example, let's generate a `!help` command:
+
+```ts
+const ping: BotFunction = {
+  name: 'ping',
+  description: 'Responds to your ping with a pong!\n\nUsage: ping',
+  condition: (msg) => msg.content === 'ping',
+  callback: (msg) => msg.reply('pong'),
+}
+
+const client = init({
+  functions: [ping],
+  helpCommand: '!help',
+})
+
+client.login('your.bot.token')
+```
+
+Now your bot can respond to `!help`:
+
+![Automatic documentation](https://i.imgur.com/kqBnZ5M.png)
+
+### Using discord.js features
+
+The `init` method returns a [discord.js Client](https://discord.js.org/#/docs/main/stable/class/Client).
+
+Read the [discord.js documentation](https://discord.js.org/#/docs/main/master/general/welcome) for more information about using the client.
+
+```ts
+const ping: BotFunction = {
+  name: 'ping',
+  description: 'Responds to your ping with a pong!\n\nUsage: ping',
+  condition: (msg) => msg.content === 'ping',
+  callback: (msg) => msg.reply('pong'),
+}
+
+const client = init({
+  functions: [ping],
+  helpCommand: '!help',
+})
+
+client.on('ready', () => {
+  console.log(`Logged in as ${client.user?.tag}!`)
+})
+
+client.on('message', console.log)
+
+client.login('your.bot.token')
+```
+
+## Local development
 
 Clone and install the dependencies:
 
@@ -42,8 +116,6 @@ git clone https://github.com/TomerRon/cordless.git
 cd cordless
 yarn
 ```
-
-#### Local development
 
 We recommend installing [yalc](https://github.com/wclr/yalc). Publish your changes locally with:
 
@@ -90,7 +162,7 @@ Run the e2e tests:
 yarn e2e
 ```
 
-## Contributors
+## Special thanks
 
 Huge shoutout to [fivenp](https://fivenp.com/) ([@fivenp](https://github.com/fivenp)) for the amazing visual assets. Go check out his work!
 

--- a/src/functions/help.test.ts
+++ b/src/functions/help.test.ts
@@ -1,0 +1,150 @@
+import { Message, TextChannel } from 'discord.js'
+import getHelpFunction from './help'
+import { BotFunction } from '../types'
+
+describe('getHelpFunction', () => {
+  beforeEach(jest.clearAllMocks)
+
+  const mockFunction: BotFunction = {
+    name: 'foo',
+    description: 'bar',
+    condition: () => false,
+    callback: () => undefined,
+  }
+
+  const mockCommand = '!helpme'
+
+  const helpFunction = getHelpFunction(mockCommand)
+
+  it('should return a function', () => {
+    expect(helpFunction).toMatchObject({
+      name: 'help',
+      description: `Shows this help screen.\n\nUsage: ${mockCommand} or ${mockCommand} <function>`,
+      condition: expect.any(Function),
+      callback: expect.any(Function),
+    })
+  })
+
+  describe('condition', () => {
+    const { condition } = helpFunction
+
+    it('should return true when the message content is the command', () => {
+      expect(condition({ content: mockCommand } as Message)).toBe(true)
+    })
+
+    it('should return true when the message content is the command followed by args', () => {
+      expect(condition({ content: `${mockCommand} foobar` } as Message)).toBe(
+        true,
+      )
+    })
+
+    it('should return false for other cases', () => {
+      const values: string[] = [
+        `${mockCommand}foo`,
+        `foo${mockCommand}`,
+        ` ${mockCommand}`,
+        'helpme',
+        '!helpm',
+        '! helpme',
+        'foobar',
+      ]
+
+      values.map((value) =>
+        expect(condition({ content: value } as Message)).toBe(false),
+      )
+    })
+  })
+
+  describe('callback', () => {
+    const sendSpy = jest.fn()
+
+    const { callback } = helpFunction
+    const mockMsg = {
+      channel: {
+        send: sendSpy as TextChannel['send'],
+      },
+      content: mockCommand,
+    } as Message
+
+    describe('should return the main help message', () => {
+      it('should return a list of functions when there are no unnamed functions', () => {
+        callback(mockMsg, [mockFunction])
+
+        const expected = `List of available functions: (Use \`${mockCommand} <function>\` for details about a specific function)\n>>> **${mockFunction.name}**\n`
+
+        expect(sendSpy).toHaveBeenCalledWith(expected)
+      })
+
+      it('should return a list of functions when there is one unnamed function', () => {
+        callback(mockMsg, [
+          mockFunction,
+          { condition: () => true, callback: () => undefined },
+        ])
+
+        const expected = `List of available functions: (Use \`${mockCommand} <function>\` for details about a specific function)\n>>> **${mockFunction.name}**\n\nThere is also 1 unnamed function.`
+
+        expect(sendSpy).toHaveBeenCalledWith(expected)
+      })
+
+      it('should return a list of functions when there are multiple unnamed functions', () => {
+        callback(mockMsg, [
+          mockFunction,
+          { condition: () => true, callback: () => undefined },
+          { condition: () => true, callback: () => undefined },
+        ])
+
+        const expected = `List of available functions: (Use \`${mockCommand} <function>\` for details about a specific function)\n>>> **${mockFunction.name}**\n\nThere are also 2 unnamed functions.`
+
+        expect(sendSpy).toHaveBeenCalledWith(expected)
+      })
+    })
+
+    describe('should return details for a specific function', () => {
+      it('with a description', () => {
+        callback(
+          {
+            ...mockMsg,
+            content: `${mockCommand} ${mockFunction.name}`,
+          } as Message,
+          [mockFunction],
+        )
+
+        const expected = `>>> **${mockFunction.name}**\n${mockFunction.description}`
+
+        expect(sendSpy).toHaveBeenCalledWith(expected)
+      })
+
+      it('without a description', () => {
+        const fn: BotFunction = { ...mockFunction, description: undefined }
+
+        callback(
+          {
+            ...mockMsg,
+            content: `${mockCommand} ${fn.name}`,
+          } as Message,
+          [fn],
+        )
+
+        const expected = `>>> **${fn.name}**\nNo description.`
+
+        expect(sendSpy).toHaveBeenCalledWith(expected)
+      })
+
+      it('should return an error message if called with a non-existent function', () => {
+        const fnName = 'does-not-exist'
+
+        callback(
+          {
+            ...mockMsg,
+            content: `${mockCommand} ${fnName}`,
+          } as Message,
+          [mockFunction],
+        )
+
+        const expected = `There's no function called **${fnName}**. Use \`${mockCommand}\` for a list of all functions.`
+
+        expect(sendSpy).toHaveBeenCalledWith(expected)
+      })
+    })
+  })
+})

--- a/src/functions/help.ts
+++ b/src/functions/help.ts
@@ -1,0 +1,44 @@
+import { BotFunction } from '../types'
+
+const getHelpFunction = (command: string): BotFunction => ({
+  name: 'help',
+  description: `Shows this help screen.\n\nUsage: ${command} or ${command} <function>`,
+  condition: (msg) =>
+    msg.content === command || msg.content.startsWith(`${command} `),
+  callback: (msg, functions) => {
+    const functionName = msg.content.split(' ')[1]
+
+    const getAllFunctions = () => {
+      const namedFunctions = functions.filter((f) => f.name)
+      const unnamedFunctionsCount = functions.length - namedFunctions.length
+
+      const namedFunctionsString = namedFunctions
+        .map(({ name }) => `**${name}**\n`)
+        .join('')
+      const unnamedFunctionsString =
+        unnamedFunctionsCount > 1
+          ? `\nThere are also ${unnamedFunctionsCount} unnamed functions.`
+          : unnamedFunctionsCount === 1
+          ? `\nThere is also 1 unnamed function.`
+          : ''
+
+      return `List of available functions: (Use \`${command} <function>\` for details about a specific function)\n>>> ${namedFunctionsString}${unnamedFunctionsString}`
+    }
+
+    const getFunctionDetails = () => {
+      const fn = functions.find((f) => f.name === functionName)
+
+      if (!fn) {
+        return `There's no function called **${functionName}**. Use \`${command}\` for a list of all functions.`
+      }
+
+      return `>>> **${fn.name}**\n${fn.description || 'No description.'}`
+    }
+
+    const response = functionName ? getFunctionDetails() : getAllFunctions()
+
+    msg.channel.send(response)
+  },
+})
+
+export default getHelpFunction

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -1,7 +1,8 @@
 import { Client, Message } from 'discord.js'
 import { init } from './init'
+import * as getHelpFunctionModule from './functions/help'
+import { BotFunction, InitOptions } from './types'
 import * as handleMessageModule from './utils/handleMessage'
-import { InitOptions } from './types'
 
 const onSpy = jest.fn()
 const mockBaseClient = ({ on: onSpy } as unknown) as Client
@@ -17,29 +18,82 @@ describe('init', () => {
     content: 'ping',
   } as Message
 
-  const mockOptions: InitOptions = { functions: [] }
+  const mockFunction: BotFunction = {
+    condition: (msg) => msg.content === 'ping',
+    callback: jest.fn(),
+  }
+
+  const mockOptions: InitOptions = { functions: [mockFunction] }
 
   const handleMessageSpy = jest
     .spyOn(handleMessageModule, 'default')
     .mockResolvedValue(undefined)
 
+  const setupTest = (options?: Partial<InitOptions>) => {
+    init({ ...mockOptions, ...options })
+
+    return onSpy.mock.calls[0][1] as (msg: Message) => void
+  }
+
   it('should subscribe to message events', () => {
-    init(mockOptions)
+    setupTest()
 
     expect(onSpy).toHaveBeenCalledWith('message', expect.any(Function))
   })
 
   it('should call handleMessage when a message was received', () => {
-    init(mockOptions)
-
-    const onMessageHandler = onSpy.mock.calls[0][1] as (msg: Message) => void
+    const onMessageHandler = setupTest()
 
     onMessageHandler(mockMsg)
 
     expect(handleMessageSpy).toHaveBeenCalledWith(
       mockMsg,
       mockBaseClient,
-      mockOptions,
+      mockOptions.functions,
     )
+  })
+
+  it('should throw an error if a function has spaces in its name', () => {
+    const badFn: BotFunction = { ...mockFunction, name: 'bad name' }
+
+    expect(() => setupTest({ functions: [badFn] })).toThrow(
+      'A function cannot have spaces in its name.',
+    )
+  })
+
+  describe('helpCommand', () => {
+    const mockHelpFunction: BotFunction = {
+      name: 'help',
+      condition: () => true,
+      callback: () => undefined,
+    }
+
+    const getHelpFunctionSpy = jest
+      .spyOn(getHelpFunctionModule, 'default')
+      .mockReturnValue(mockHelpFunction)
+
+    it('should add a help function when helpCommand is passed', () => {
+      const mockHelpCommand = 'foobar-help-command'
+      const onMessageHandler = setupTest({ helpCommand: mockHelpCommand })
+
+      onMessageHandler(mockMsg)
+
+      const functions = handleMessageSpy.mock.calls[0][2]
+
+      // The first function should be the one returned from getHelpFunction
+      expect(functions[0]).toStrictEqual(mockHelpFunction)
+      expect(getHelpFunctionSpy).toHaveBeenCalledWith(mockHelpCommand)
+    })
+
+    it('should not add a help function when helpCommand is not passed', () => {
+      const onMessageHandler = setupTest({ helpCommand: undefined })
+
+      onMessageHandler(mockMsg)
+
+      const functions = handleMessageSpy.mock.calls[0][2]
+
+      expect(functions[0]).not.toStrictEqual(mockHelpFunction)
+      expect(getHelpFunctionSpy).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,5 +1,6 @@
 import Discord from 'discord.js'
-import { InitOptions } from './types'
+import getHelpFunction from './functions/help'
+import { BotFunction, InitOptions } from './types'
 import handleMessage from './utils/handleMessage'
 
 /**
@@ -7,9 +8,20 @@ import handleMessage from './utils/handleMessage'
  * Returns a discord.js client.
  */
 export const init = (options: InitOptions): Discord.Client => {
+  const { functions, helpCommand } = options
+  let resolvedFns: BotFunction[] = functions
+
+  if (functions.some((fn) => fn.name?.includes(' '))) {
+    throw new Error('A function cannot have spaces in its name.')
+  }
+
   const client = new Discord.Client()
 
-  client.on('message', (msg) => handleMessage(msg, client, options))
+  if (helpCommand) {
+    resolvedFns = [getHelpFunction(helpCommand), ...functions]
+  }
+
+  client.on('message', (msg) => handleMessage(msg, client, resolvedFns))
 
   return client
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,13 +4,33 @@ import Discord from 'discord.js'
 export type InitOptions = {
   /** The functions used by your bot */
   functions: BotFunction[]
+  /**
+   * Generate a help function for the bot, which will be triggered by the value.
+   *
+   * For example, given a value of "!help", the following commands will be available:
+   *
+   * - !help (shows a list of available functions)
+   * - !help <function-name> (shows a description and usage instructions for the given function)
+   */
+  helpCommand?: string
 }
 
 export type BotFunction = {
+  /**
+   * The name of this function (no spaces allowed).
+   * It will be displayed in the help function if there is a helpCommand.
+   */
+  name?: string
+  /**
+   * The description of this function and usage instructions.
+   * It will be displayed in the help function if there is a helpCommand.
+   */
+  description?: string
   /** Determines whether or not this function should run */
   condition: (msg: Discord.Message) => boolean
   /** Called whenever this function should run */
   callback: (
     msg: Discord.Message,
+    functions: BotFunction[],
   ) => void | Promise<void> | Promise<Discord.Message>
 }

--- a/src/utils/handleMessage.test.ts
+++ b/src/utils/handleMessage.test.ts
@@ -1,6 +1,6 @@
 import { Client, Message, User } from 'discord.js'
 import handleMessage from './handleMessage'
-import { InitOptions, BotFunction } from '../types'
+import { BotFunction } from '../types'
 
 describe('handleMessage', () => {
   beforeEach(jest.clearAllMocks)
@@ -27,25 +27,23 @@ describe('handleMessage', () => {
     callback: pingCallbackSpy,
   }
 
-  const mockOptions: InitOptions = {
-    functions: [pingFunction],
-  }
+  const mockFunctions: BotFunction[] = [pingFunction]
 
   const setupTest: (args?: {
     msg?: Partial<Omit<Message, 'valueOf'>>
     client?: Partial<Client>
-    options?: Partial<InitOptions>
-  }) => Promise<void> = ({ msg, client, options } = {}) =>
+    functions?: BotFunction[]
+  }) => Promise<void> = ({ msg, client, functions = [] } = {}) =>
     handleMessage(
       { ...mockMsg, ...msg } as Message,
       { ...mockClient, ...client } as Client,
-      { ...mockOptions, ...options } as InitOptions,
+      [...mockFunctions, ...functions],
     )
 
   it("should call a function's callback if it matches the condition", async () => {
     await setupTest()
 
-    expect(pingCallbackSpy).toHaveBeenCalledWith(mockMsg)
+    expect(pingCallbackSpy).toHaveBeenCalledWith(mockMsg, mockFunctions)
   })
 
   it("should not call a function's callback if it does not match the condition", async () => {

--- a/src/utils/handleMessage.ts
+++ b/src/utils/handleMessage.ts
@@ -1,20 +1,18 @@
 import { Client, Message } from 'discord.js'
-import { InitOptions } from '../types'
+import { BotFunction } from '../types'
 
 const handleMessage = async (
   msg: Message,
   client: Client,
-  options: InitOptions,
+  functions: BotFunction[],
 ): Promise<void> => {
-  const { functions } = options
-
   if (!client.user || msg.author.id === client.user.id) {
     return
   }
 
   const result = functions.find(({ condition }) => condition(msg))
 
-  await result?.callback(msg)
+  await result?.callback(msg, functions)
 }
 
 export default handleMessage


### PR DESCRIPTION
This PR implements:

- The client can be initialized with a helpCommand, which will generate a help function.
For example, passing `helpCommand: "!help"` will add the commands `!help` and `!help <function>`.

- The callback of bot functions now receive the resolved functions as the second argument