### PR TITLE
feat(context): Add Context

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,15 @@
     "prettier/@typescript-eslint"
   ],
   "rules": {
+    "@typescript-eslint/ban-types": [
+      "error",
+      {
+        "types": {
+          "{}": false
+        },
+        "extendDefaults": true
+      }
+    ],
     "arrow-body-style": [2, "as-needed"],
     "indent": [0],
     "import/no-unresolved": "off",

--- a/e2e/context.test.ts
+++ b/e2e/context.test.ts
@@ -1,0 +1,99 @@
+import { Client } from 'discord.js'
+import { v4 as uuidv4 } from 'uuid'
+import { setupClients } from './utils'
+import { BotFunction, Context } from '../src'
+
+interface CustomContext {
+  foo: string
+  getCount: () => number
+  setCount: (count: number) => void
+}
+
+describe('context', () => {
+  let cordlessClient: Client
+  let userClient: Client
+  let sendMessageAndWaitForIt: (content: string) => Promise<void>
+
+  const testPing = uuidv4()
+
+  const pingCallbackSpy = jest.fn()
+  const ping: BotFunction<CustomContext> = {
+    condition: (msg) => msg.content === testPing,
+    callback: pingCallbackSpy,
+  }
+
+  const mockFunctions = [ping]
+
+  let mockCount = 0
+
+  const mockCustomContext: CustomContext = {
+    foo: 'bar',
+    getCount: () => mockCount,
+    setCount: (count: number) => {
+      mockCount = count
+    },
+  }
+
+  beforeAll(async () => {
+    const setup = await setupClients({
+      context: mockCustomContext,
+      functions: mockFunctions,
+      helpCommand: 'foobar',
+    })
+
+    cordlessClient = setup.cordlessClient
+    userClient = setup.userClient
+    sendMessageAndWaitForIt = setup.sendMessageAndWaitForIt
+
+    await sendMessageAndWaitForIt(testPing)
+  })
+
+  afterAll(() => {
+    cordlessClient.destroy()
+    userClient.destroy()
+  })
+
+  it('should have access to the client', async () => {
+    const { client } = pingCallbackSpy.mock.calls[0][1] as Context<
+      CustomContext
+    >
+
+    expect(client.user?.id).toBe(cordlessClient.user?.id)
+  })
+
+  it('should have access to the functions', async () => {
+    const { functions } = pingCallbackSpy.mock.calls[0][1] as Context<
+      CustomContext
+    >
+
+    expect(functions).toStrictEqual([
+      expect.objectContaining({ name: 'help' }),
+      ...mockFunctions,
+    ])
+  })
+
+  it('should have access to custom context', async () => {
+    const { foo } = pingCallbackSpy.mock.calls[0][1] as Context<CustomContext>
+
+    expect(foo).toBe(mockCustomContext.foo)
+  })
+
+  it('should be able to persist the context between function calls', async () => {
+    const { getCount, setCount } = pingCallbackSpy.mock.calls[0][1] as Context<
+      CustomContext
+    >
+
+    expect(getCount()).toBe(0)
+
+    setCount(1)
+
+    expect(getCount()).toBe(1)
+
+    await sendMessageAndWaitForIt(testPing)
+
+    const { getCount: getCountSecondPing } = pingCallbackSpy.mock
+      .calls[1][1] as Context<CustomContext>
+
+    expect(getCountSecondPing()).toBe(1)
+  })
+})

--- a/e2e/setupTests.ts
+++ b/e2e/setupTests.ts
@@ -1,0 +1,8 @@
+/**
+ * Wait 1 second before each test.
+ * This is required to prevent flakiness.
+ * Otherwise, the client might fail to login.
+ */
+beforeEach(async () => {
+  await new Promise<void>((resolve) => setTimeout(resolve, 1000))
+})

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -1,0 +1,58 @@
+import { init, InitOptions, CustomContext } from '../src'
+import { Client, TextChannel, Message } from 'discord.js'
+import dotenv from 'dotenv'
+
+dotenv.config()
+
+export const setupClients = async <T extends CustomContext>(
+  options: InitOptions<T>,
+): Promise<{
+  cordlessClient: Client
+  userClient: Client
+  e2eChannel: TextChannel
+  sendMessageAndWaitForIt: (content: string) => Promise<void>
+}> => {
+  // Login as the cordless client
+  const cordlessClient = init(options)
+
+  await new Promise<void>((resolve) => {
+    cordlessClient.on('ready', resolve)
+
+    cordlessClient.login(process.env.E2E_CLIENT_TOKEN)
+  })
+
+  // Login as the test user
+  const userClient = new Client()
+
+  await new Promise<void>((resolve) => {
+    userClient.on('ready', resolve)
+
+    userClient.login(process.env.E2E_USER_TOKEN)
+  })
+
+  // Get the channel for e2e testing
+  const e2eChannel = userClient.channels.cache.get(
+    process.env.E2E_CHANNEL_ID || '',
+  ) as TextChannel
+
+  // Sends a message as the user client, and waits until it is received by the cordless client
+  const sendMessageAndWaitForIt = (content: string) =>
+    new Promise<void>((resolve) => {
+      const resolveIfMatchesContent = (msg: Message) => {
+        if (msg.content === content) {
+          cordlessClient.off('message', resolveIfMatchesContent)
+          resolve()
+        }
+      }
+
+      cordlessClient.on('message', resolveIfMatchesContent)
+      e2eChannel.send(content)
+    })
+
+  return {
+    cordlessClient,
+    userClient,
+    e2eChannel,
+    sendMessageAndWaitForIt,
+  }
+}

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -20,6 +20,7 @@ const config: Config.InitialOptions = {
       statements: 100,
     },
   },
+  rootDir: 'src',
 }
 
 export default config

--- a/jest.e2e.config.ts
+++ b/jest.e2e.config.ts
@@ -1,0 +1,11 @@
+import { Config } from '@jest/types'
+
+const config: Config.InitialOptions = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  collectCoverage: false,
+  setupFilesAfterEnv: ['<rootDir>/setupTests.ts'],
+  rootDir: 'e2e',
+}
+
+export default config

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "scripts": {
     "build": "rm -rf dist && tsc",
     "lint": "eslint . --ext .ts",
-    "test": "jest --rootDir src",
-    "e2e": "jest --coverage=false --rootDir e2e",
+    "test": "jest",
+    "e2e": "jest --config=jest.e2e.config.ts --runInBand",
     "postinstall": "husky install",
     "prepublishOnly": "yarn build && pinst --disable",
     "postpublish": "pinst --enable",

--- a/src/functions/help.ts
+++ b/src/functions/help.ts
@@ -1,11 +1,14 @@
-import { BotFunction } from '../types'
+import { BotFunction, CustomContext } from '../types'
 
-const getHelpFunction = (command: string): BotFunction => ({
+const getHelpFunction = <T extends CustomContext>(
+  command: string,
+): BotFunction<T> => ({
   name: 'help',
   description: `Shows this help screen.\n\nUsage: ${command} or ${command} <function>`,
   condition: (msg) =>
     msg.content === command || msg.content.startsWith(`${command} `),
-  callback: (msg, functions) => {
+  callback: (msg, context) => {
+    const { functions } = context
     const functionName = msg.content.split(' ')[1]
 
     const getAllFunctions = () => {

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -46,11 +46,10 @@ describe('init', () => {
 
     onMessageHandler(mockMsg)
 
-    expect(handleMessageSpy).toHaveBeenCalledWith(
-      mockMsg,
-      mockBaseClient,
-      mockOptions.functions,
-    )
+    expect(handleMessageSpy).toHaveBeenCalledWith(mockMsg, {
+      client: mockBaseClient,
+      functions: mockOptions.functions,
+    })
   })
 
   it('should throw an error if a function has spaces in its name', () => {
@@ -78,10 +77,10 @@ describe('init', () => {
 
       onMessageHandler(mockMsg)
 
-      const functions = handleMessageSpy.mock.calls[0][2]
+      const context = handleMessageSpy.mock.calls[0][1]
 
       // The first function should be the one returned from getHelpFunction
-      expect(functions[0]).toStrictEqual(mockHelpFunction)
+      expect(context.functions[0]).toStrictEqual(mockHelpFunction)
       expect(getHelpFunctionSpy).toHaveBeenCalledWith(mockHelpCommand)
     })
 
@@ -90,9 +89,9 @@ describe('init', () => {
 
       onMessageHandler(mockMsg)
 
-      const functions = handleMessageSpy.mock.calls[0][2]
+      const context = handleMessageSpy.mock.calls[0][1]
 
-      expect(functions[0]).not.toStrictEqual(mockHelpFunction)
+      expect(context.functions[0]).not.toStrictEqual(mockHelpFunction)
       expect(getHelpFunctionSpy).not.toHaveBeenCalled()
     })
   })

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,15 +1,16 @@
 import Discord from 'discord.js'
 import getHelpFunction from './functions/help'
-import { BotFunction, InitOptions } from './types'
+import { Context, CustomContext, InitOptions } from './types'
 import handleMessage from './utils/handleMessage'
 
 /**
  * Initializes a cordless bot with the given options.
  * Returns a discord.js client.
  */
-export const init = (options: InitOptions): Discord.Client => {
+export const init = <T extends CustomContext = {}>(
+  options: InitOptions<T>,
+): Discord.Client => {
   const { functions, helpCommand } = options
-  let resolvedFns: BotFunction[] = functions
 
   if (functions.some((fn) => fn.name?.includes(' '))) {
     throw new Error('A function cannot have spaces in its name.')
@@ -17,11 +18,17 @@ export const init = (options: InitOptions): Discord.Client => {
 
   const client = new Discord.Client()
 
-  if (helpCommand) {
-    resolvedFns = [getHelpFunction(helpCommand), ...functions]
+  const resolvedFns = helpCommand
+    ? [getHelpFunction<T>(helpCommand), ...functions]
+    : functions
+
+  const context: Context<T> = {
+    client,
+    functions: resolvedFns,
+    ...(options.context as T),
   }
 
-  client.on('message', (msg) => handleMessage(msg, client, resolvedFns))
+  client.on('message', (msg) => handleMessage(msg, context))
 
   return client
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,11 @@
 import Discord from 'discord.js'
 
 /** Initialization options for your cordless bot */
-export type InitOptions = {
+export type InitOptions<T extends CustomContext = {}> = {
   /** The functions used by your bot */
-  functions: BotFunction[]
+  functions: BotFunction<T>[]
+  /** A custom context object which will extend the context passed to your functions' callbacks and conditions */
+  context?: T
   /**
    * Generate a help function for the bot, which will be triggered by the value.
    *
@@ -15,7 +17,7 @@ export type InitOptions = {
   helpCommand?: string
 }
 
-export type BotFunction = {
+export type BotFunction<T extends CustomContext = {}> = {
   /**
    * The name of this function (no spaces allowed).
    * It will be displayed in the help function if there is a helpCommand.
@@ -27,10 +29,18 @@ export type BotFunction = {
    */
   description?: string
   /** Determines whether or not this function should run */
-  condition: (msg: Discord.Message) => boolean
+  condition: (msg: Discord.Message, context: Context<T>) => boolean
   /** Called whenever this function should run */
   callback: (
     msg: Discord.Message,
-    functions: BotFunction[],
+    context: Context<T>,
   ) => void | Promise<void> | Promise<Discord.Message>
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type CustomContext = Record<string, any>
+
+export type Context<T extends CustomContext = {}> = {
+  client: Discord.Client
+  functions: BotFunction<T>[]
+} & T

--- a/src/utils/handleMessage.ts
+++ b/src/utils/handleMessage.ts
@@ -1,18 +1,19 @@
-import { Client, Message } from 'discord.js'
-import { BotFunction } from '../types'
+import { Message } from 'discord.js'
+import { Context, CustomContext } from '../types'
 
-const handleMessage = async (
+const handleMessage = async <T extends CustomContext>(
   msg: Message,
-  client: Client,
-  functions: BotFunction[],
+  context: Context<T>,
 ): Promise<void> => {
+  const { client, functions } = context
+
   if (!client.user || msg.author.id === client.user.id) {
     return
   }
 
-  const result = functions.find(({ condition }) => condition(msg))
+  const result = functions.find(({ condition }) => condition(msg, context))
 
-  await result?.callback(msg, functions)
+  await result?.callback(msg, context)
 }
 
 export default handleMessage

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,12 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "exclude": ["node_modules", "dist", "jest.config.ts", "**/*.test.ts"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "e2e",
+    "jest.config.ts",
+    "jest.e2e.config.ts",
+    "**/*.test.ts"
+  ]
 }


### PR DESCRIPTION
This PR implements:

- Base context, which includes the `discord.js` client and the list of functions used by the bot
- Custom context, which can be passed on initialization and extends the base context object

Context is passed to each function's `condition` and `callback`.