### PR TITLE
feat(client): Allow overriding of default Gateway Intents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![cordless](assets/splash.png)](#)
 
-<h3 align="center">Opinionated framework for creating Discord bots with minimal boilerplate</h3>
+<h3 align="center">Simple framework for creating Discord bots with minimal boilerplate</h3>
 <p align="center">
   <a href="https://www.npmjs.com/package/cordless">
     <img alt="npm latest version" src="https://img.shields.io/npm/v/cordless/latest.svg">
@@ -56,6 +56,7 @@ cordless.init({ functions: [ping] }).login('your.bot.token')
   - [Automatic documentation](#automatic-documentation)
   - [Share business logic with Context](#share-business-logic-with-context)
   - [Using discord.js features](#using-discordjs-features)
+  - [Overriding the default Gateway Intents](#overriding-the-default-gateway-intents)
 - [Local development](#local-development)
 - [Special thanks](#special-thanks)
 - [License](#license)
@@ -167,7 +168,7 @@ const client = cordless.init({
 
 The `init` method returns a [discord.js Client](https://discord.js.org/#/docs/main/stable/class/Client).
 
-Read the [discord.js documentation](https://discord.js.org/#/docs/main/master/general/welcome) for more information about using the client.
+Read the [discord.js documentation](https://discord.js.org/#/docs) for more information about using the client.
 
 ```ts
 const client = init({
@@ -182,6 +183,35 @@ client.on('messageCreate', console.log)
 
 client.login('your.bot.token')
 ```
+
+### Overriding the default Gateway Intents
+
+By default, cordless initializes the discord.js client with the [Gateway Intents](https://discord.com/developers/docs/topics/gateway#gateway-intents) `[GUILDS, GUILD_MESSAGES]`. This should be sufficient for most bots that simply need to receive messages and do something in response.
+
+You can provide your own list of intents if you need additional functionality. For example, this bot can handle inviteCreate and inviteDelete events, in addition to handling messages as usual:
+
+```ts
+import { Intents } from 'discord.js'
+
+const client = init({
+  // ...
+  intents: [
+    Intents.FLAGS.GUILDS,
+    Intents.FLAGS.GUILD_MESSAGES,
+    Intents.FLAGS.GUILD_INVITES,
+  ],
+})
+
+// Without the GUILD_INVITES intent, these will not work
+client.on('inviteCreate', console.log)
+client.on('inviteDelete', console.log)
+
+client.login('your.bot.token')
+```
+
+For more information about Gateway Intents, see:
+https://discord.com/developers/docs/topics/gateway#gateway-intents
+https://discordjs.guide/popular-topics/intents.html
 
 ## Local development
 

--- a/e2e/callback.test.ts
+++ b/e2e/callback.test.ts
@@ -11,9 +11,9 @@ describe('callback', () => {
 
   const pingCallbackSpy = jest.fn()
 
-  const testPing = uuidv4()
-  const testWrongPing = uuidv4()
-  const testPong = uuidv4()
+  const testPing = `[callback] ${uuidv4()}`
+  const testWrongPing = `[callback] ${uuidv4()}`
+  const testPong = `[callback] ${uuidv4()}`
 
   beforeEach(() => {
     receivedMessages = []

--- a/e2e/context.test.ts
+++ b/e2e/context.test.ts
@@ -1,4 +1,4 @@
-import { Client } from 'discord.js'
+import { Client, Message } from 'discord.js'
 import { v4 as uuidv4 } from 'uuid'
 import { BotFunction, Context } from '../src'
 import { setupClients } from './utils'
@@ -12,7 +12,7 @@ interface CustomContext {
 describe('context', () => {
   let cordlessClient: Client
   let userClient: Client
-  let sendMessageAndWaitForIt: (content: string) => Promise<void>
+  let sendMessageAndWaitForIt: (content: string) => Promise<Message>
 
   const testPing = uuidv4()
 

--- a/e2e/context.test.ts
+++ b/e2e/context.test.ts
@@ -14,7 +14,7 @@ describe('context', () => {
   let userClient: Client
   let sendMessageAndWaitForIt: (content: string) => Promise<Message>
 
-  const testPing = uuidv4()
+  const testPing = `[context] - ${uuidv4()}`
 
   const pingCallbackSpy = jest.fn()
   const ping: BotFunction<CustomContext> = {

--- a/e2e/intents.test.ts
+++ b/e2e/intents.test.ts
@@ -8,7 +8,7 @@ describe('intents', () => {
   let userClient: Client
   let sendMessageAndWaitForIt: (content: string) => Promise<Message>
 
-  const testPing = uuidv4()
+  const testPing = `[intents] - ${uuidv4()}`
 
   const setupTest = async (intents?: InitOptions['intents']) => {
     const setup = await setupClients({

--- a/e2e/intents.test.ts
+++ b/e2e/intents.test.ts
@@ -1,0 +1,80 @@
+import { Client, Intents, Message } from 'discord.js'
+import { v4 as uuidv4 } from 'uuid'
+import { InitOptions } from '../src'
+import { setupClients } from './utils'
+
+describe('intents', () => {
+  let cordlessClient: Client
+  let userClient: Client
+  let sendMessageAndWaitForIt: (content: string) => Promise<Message>
+
+  const testPing = uuidv4()
+
+  const setupTest = async (intents?: InitOptions['intents']) => {
+    const setup = await setupClients({
+      functions: [],
+      intents,
+    })
+
+    cordlessClient = setup.cordlessClient
+    userClient = setup.userClient
+    sendMessageAndWaitForIt = setup.sendMessageAndWaitForIt
+  }
+
+  afterEach(async () => {
+    // In this file we have to create a new client in each test
+    // So we wait 1 second between tests to prevent flakiness
+    await new Promise<void>((resolve) => setTimeout(resolve, 1000))
+  })
+
+  describe('when initialized without the GUILD_MESSAGES intent', () => {
+    beforeAll(async () => {
+      await setupTest([Intents.FLAGS.GUILDS])
+    })
+
+    afterAll(() => {
+      cordlessClient.destroy()
+      userClient.destroy()
+    })
+
+    it('should not receive the message', async () => {
+      await expect(sendMessageAndWaitForIt(testPing)).rejects.toThrow(
+        'Message was not received by the client.',
+      )
+    })
+  })
+
+  describe('when initialized with the GUILD_MESSAGES intent', () => {
+    beforeAll(async () => {
+      await setupTest([Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES])
+    })
+
+    afterAll(() => {
+      cordlessClient.destroy()
+      userClient.destroy()
+    })
+
+    it('should receive the message', async () => {
+      const message = await sendMessageAndWaitForIt(testPing)
+
+      expect(message.id).toBeDefined()
+    })
+  })
+
+  describe('when initialized with the default intents', () => {
+    beforeAll(async () => {
+      await setupTest()
+    })
+
+    afterAll(() => {
+      cordlessClient.destroy()
+      userClient.destroy()
+    })
+
+    it('should receive the message', async () => {
+      const message = await sendMessageAndWaitForIt(testPing)
+
+      expect(message.id).toBeDefined()
+    })
+  })
+})

--- a/e2e/setupTests.ts
+++ b/e2e/setupTests.ts
@@ -6,3 +6,5 @@
 beforeEach(async () => {
   await new Promise<void>((resolve) => setTimeout(resolve, 2000))
 })
+
+jest.setTimeout(10000)

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -48,6 +48,19 @@ describe('init', () => {
     })
   })
 
+  it('should initialize the client with the provided intents', () => {
+    const intents = [
+      Intents.FLAGS.GUILD_BANS,
+      Intents.FLAGS.GUILD_EMOJIS_AND_STICKERS,
+    ]
+
+    setupTest({ intents })
+
+    expect(Client).toHaveBeenCalledWith({
+      intents,
+    })
+  })
+
   it('should subscribe to message events', () => {
     setupTest()
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,7 +1,12 @@
-import Discord from 'discord.js'
+import Discord, { ClientOptions, Intents } from 'discord.js'
 import getHelpFunction from './functions/help'
 import { Context, CustomContext, InitOptions } from './types'
 import handleMessage from './utils/handleMessage'
+
+const DEFAULT_INTENTS: ClientOptions['intents'] = [
+  Intents.FLAGS.GUILD_MESSAGES,
+  Intents.FLAGS.GUILDS,
+]
 
 /**
  * Initializes a cordless bot with the given options.
@@ -10,18 +15,11 @@ import handleMessage from './utils/handleMessage'
 export const init = <T extends CustomContext = {}>(
   options: InitOptions<T>,
 ): Discord.Client => {
-  const { functions, helpCommand } = options
+  const { functions, helpCommand, intents = DEFAULT_INTENTS } = options
 
   if (functions.some((fn) => fn.name?.includes(' '))) {
     throw new Error('A function cannot have spaces in its name.')
   }
-
-  // @TODO: Allow passing an array of intents to this method.
-  // For now the intents are hard-coded.
-  const intents = [
-    Discord.Intents.FLAGS.GUILD_MESSAGES,
-    Discord.Intents.FLAGS.GUILDS,
-  ]
 
   const client = new Discord.Client({ intents })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import Discord from 'discord.js'
+import Discord, { ClientOptions } from 'discord.js'
 
 /** Initialization options for your cordless bot */
 export type InitOptions<T extends CustomContext = {}> = {
@@ -6,6 +6,16 @@ export type InitOptions<T extends CustomContext = {}> = {
   functions: BotFunction<T>[]
   /** A custom context object which will extend the context passed to your functions' callbacks and conditions */
   context?: T
+  /**
+   * Override the default Gateway Intents of the discord.js client.
+   *
+   * By default, the discord.js client will initialize with the [GUILDS, GUILD_MESSAGES] intents.
+   * These default intents should be sufficient in most cases.
+   *
+   * @see https://discord.com/developers/docs/topics/gateway#gateway-intents
+   * @see https://discordjs.guide/popular-topics/intents.html
+   */
+  intents?: ClientOptions['intents']
   /**
    * Generate a help function for the bot, which will be triggered by the value.
    *

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "lib": ["ESNext"],
     "declaration": true,


### PR DESCRIPTION
This PR implements a new `intents` option that can be passed in the initialization.

Passing the `intents` option overrides the default gateway intents (`[GUILDS, GUILD_MESSAGES]`).

See:
https://discord.com/developers/docs/topics/gateway#gateway-intents
https://discordjs.guide/popular-topics/intents.html