### PR TITLE
feat(commands): Add base Application Commands integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ const ping: BotFunction = {
   callback: (msg) => msg.reply('pong'),
 }
 
-init({ functions: [ping] }).login('your.bot.token')
+init({ functions: [ping], token: 'your.bot.token' })
 ```
 
 ```js
@@ -48,7 +48,7 @@ const ping = {
   callback: (msg) => msg.reply('pong'),
 }
 
-cordless.init({ functions: [ping] }).login('your.bot.token')
+cordless.init({ functions: [ping], token: 'your.bot.token' })
 ```
 
 You can also check out the [code samples](sample) for ready-to-go solutions. See: [sample/01-basic-typescript](sample/01-basic-typescript) or [sample/02-basic-javascript](sample/02-basic-javascript)
@@ -91,8 +91,6 @@ const client = init({
 client.on('ready', () => {
   console.log(`Logged in as ${client.user?.tag}!`)
 })
-
-client.login('your.bot.token')
 ```
 
 See [discord.js documentation](https://discord.js.org/#/docs) for more information about using the client.

--- a/docs/context.md
+++ b/docs/context.md
@@ -68,6 +68,7 @@ const getFoo: BotFunction<'messageCreate', MyCustomContext> = {
 init<MyCustomContext>({
   context: customContext,
   functions: [getFoo],
+  token: 'token',
 })
 ```
 
@@ -89,6 +90,7 @@ const getFoo = {
 cordless.init({
   context: customContext,
   functions: [getFoo],
+  token: 'token',
 })
 ```
 
@@ -130,5 +132,6 @@ const increment: BotFunction<'messageCreate', CounterState> = {
 init<CounterState>({
   context: state,
   functions: [getTheCount, increment],
+  token: 'token',
 })
 ```

--- a/docs/gateway-intents.md
+++ b/docs/gateway-intents.md
@@ -33,7 +33,8 @@ init({
     Intents.FLAGS.GUILD_MESSAGES,
     Intents.FLAGS.GUILD_INVITES,
   ],
-}).login('your.bot.token')
+  token: 'your.bot.token',
+})
 ```
 
 #### Gateway Intents reference

--- a/docs/help-command.md
+++ b/docs/help-command.md
@@ -6,7 +6,7 @@ Enable the help function for your bot by passing a `helpCommand`:
 
 ```ts
 init({
-  functions: [...],
+  // ...
   helpCommand: '!help',
 })
 ```
@@ -37,7 +37,8 @@ const ping: BotFunction = {
 init({
   functions: [ping],
   helpCommand: '!help',
-}).login('your.bot.token')
+  token: 'your.bot.token',
+})
 ```
 
 Now your bot can respond to `!help`:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -15,10 +15,13 @@ Setting up a Discord bot can be broken down to 3 steps:
 
 #### Step 2: Generate a bot token
 
-After creating your bot, click on "Reset Token" and confirm. You will then see the new token that was generated. Copy this token to your code.
+After creating your bot, click on "Reset Token" and confirm. You will then see the new token that was generated. Copy this token to your code (or hold onto it for now, if you didn't write any code yet).
 
 ```ts
-init({ ... }).login('your.bot.token');
+init({
+  // ...
+  token: 'your.bot.token',
+})
 ```
 
 ⚠️ **Important!** Do not share this token with anyone. It's best to store it in your environment variables and load it with [dotenv](https://github.com/motdotla/dotenv) or another env loader.
@@ -26,7 +29,10 @@ init({ ... }).login('your.bot.token');
 ```ts
 dotenv.config()
 
-init({ ... }).login(process.env.BOT_TOKEN);
+init({
+  // ...
+  token: process.env.BOT_TOKEN || '',
+})
 ```
 
 #### Step 3: Add the bot to a server

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -5,7 +5,7 @@ import { CustomContext, init, InitOptions } from '../src'
 dotenv.config()
 
 export const setupClients = async <T extends CustomContext>(
-  options: InitOptions<T>,
+  options: Omit<InitOptions<T>, 'token'>,
 ): Promise<{
   cordlessClient: Client
   userClient: Client
@@ -13,12 +13,13 @@ export const setupClients = async <T extends CustomContext>(
   sendMessageAndWaitForIt: (content: string) => Promise<Message>
 }> => {
   // Login as the cordless client
-  const cordlessClient = init(options)
+  const cordlessClient = init({
+    ...options,
+    token: process.env.E2E_CLIENT_TOKEN || '',
+  })
 
   await new Promise<void>((resolve) => {
     cordlessClient.on('ready', () => resolve())
-
-    cordlessClient.login(process.env.E2E_CLIENT_TOKEN)
   })
 
   // Login as the test user

--- a/package.json
+++ b/package.json
@@ -58,6 +58,9 @@
     "uuid": "^8.3.2"
   },
   "dependencies": {
+    "@discordjs/builders": "^0.15.0",
+    "@discordjs/rest": "^0.5.0",
+    "discord-api-types": "^0.36.2",
     "discord.js": "^13.8.1"
   }
 }

--- a/src/__snapshots__/init.test.ts.snap
+++ b/src/__snapshots__/init.test.ts.snap
@@ -23,6 +23,19 @@ Array [
     ],
     Object {
       "client": Object {
+        "login": [MockFunction] {
+          "calls": Array [
+            Array [
+              "mock-token",
+            ],
+          ],
+          "results": Array [
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+          ],
+        },
         "on": [MockFunction] {
           "calls": Array [
             Array [
@@ -109,6 +122,19 @@ Array [
     ],
     Object {
       "client": Object {
+        "login": [MockFunction] {
+          "calls": Array [
+            Array [
+              "mock-token",
+            ],
+          ],
+          "results": Array [
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+          ],
+        },
         "on": [MockFunction] {
           "calls": Array [
             Array [
@@ -189,6 +215,19 @@ Array [
     ],
     Object {
       "client": Object {
+        "login": [MockFunction] {
+          "calls": Array [
+            Array [
+              "mock-token",
+            ],
+          ],
+          "results": Array [
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+          ],
+        },
         "on": [MockFunction] {
           "calls": Array [
             Array [

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -1,0 +1,155 @@
+import { SlashCommandBuilder } from '@discordjs/builders'
+import { Client, Interaction } from 'discord.js'
+import { BotCommand, Context } from '../types'
+import initCommands, { InitCommandsArgs } from './init'
+import * as buildModule from './utils/build'
+import * as handleCommandModule from './utils/handleCommand'
+import * as startRestClientModule from './utils/startRestClient'
+
+describe('initCommands', () => {
+  beforeEach(jest.clearAllMocks)
+
+  const mockApplicationId = 'mock-application-id'
+  const mockClient: Client = { on: jest.fn() } as unknown as Client
+  const mockCommands: BotCommand[] = ['botCommand' as unknown as BotCommand]
+  const mockContext: Context = { client: mockClient, functions: [] }
+  const mockToken = 'mock-token'
+
+  const mockArgs: InitCommandsArgs<{}> = {
+    applicationId: mockApplicationId,
+    client: mockClient,
+    commands: mockCommands,
+    context: mockContext,
+    token: mockToken,
+  }
+
+  const mockResolvedCommands: SlashCommandBuilder[] = [
+    'slashCommandBuilder' as unknown as SlashCommandBuilder,
+  ]
+
+  const buildSpy = jest
+    .spyOn(buildModule, 'default')
+    .mockReturnValue(mockResolvedCommands)
+
+  const startRestClientSpy = jest
+    .spyOn(startRestClientModule, 'default')
+    .mockReturnValue(undefined)
+
+  describe('when the commands are successfully initialized', () => {
+    beforeEach(() => {
+      initCommands(mockArgs)
+    })
+
+    it('starts a REST client and subscribes to interactionCreate', () => {
+      expect(buildSpy).toHaveBeenCalledWith(mockCommands)
+      expect(startRestClientSpy).toHaveBeenCalledWith({
+        applicationId: mockApplicationId,
+        commands: mockResolvedCommands,
+        token: mockToken,
+      })
+      expect(mockClient.on).toHaveBeenCalledWith(
+        'interactionCreate',
+        expect.any(Function),
+      )
+    })
+
+    describe('interactionCreate handler', () => {
+      let interactionCreateHandler: (interaction: Interaction) => void
+
+      const handleCommandSpy = jest
+        .spyOn(handleCommandModule, 'default')
+        .mockResolvedValue(undefined)
+
+      const isCommandSpy = jest.fn()
+
+      const mockInteraction = {
+        isCommand: isCommandSpy,
+      } as unknown as Interaction
+
+      beforeEach(() => {
+        interactionCreateHandler = (mockClient.on as jest.Mock).mock
+          .calls[0][1] as (interaction: Interaction) => void
+      })
+
+      describe('when the interaction is a command', () => {
+        beforeEach(() => {
+          isCommandSpy.mockReturnValueOnce(true)
+        })
+
+        it('calls handleCommand', () => {
+          interactionCreateHandler(mockInteraction)
+
+          expect(isCommandSpy).toHaveBeenCalled()
+          expect(handleCommandSpy).toHaveBeenCalledWith({
+            commands: mockCommands,
+            context: mockContext,
+            interaction: mockInteraction,
+          })
+        })
+      })
+
+      describe('when the interaction is not a command', () => {
+        beforeEach(() => {
+          isCommandSpy.mockReturnValueOnce(false)
+        })
+
+        it('does nothing', () => {
+          interactionCreateHandler(mockInteraction)
+
+          expect(isCommandSpy).toHaveBeenCalled()
+          expect(handleCommandSpy).not.toHaveBeenCalled()
+        })
+      })
+    })
+  })
+
+  describe('when there are no commands', () => {
+    beforeEach(() => {
+      buildSpy.mockReturnValueOnce([])
+    })
+
+    it('does nothing', () => {
+      initCommands({ ...mockArgs, commands: [] })
+
+      expect(buildSpy).toHaveBeenCalledWith([])
+      expect(startRestClientSpy).not.toHaveBeenCalled()
+      expect(mockClient.on).not.toHaveBeenCalled()
+    })
+
+    it('does nothing even when applicationId was not provided', () => {
+      initCommands({ ...mockArgs, commands: [], applicationId: undefined })
+
+      expect(buildSpy).toHaveBeenCalledWith([])
+      expect(startRestClientSpy).not.toHaveBeenCalled()
+      expect(mockClient.on).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when there are commands but the applicationId was not provided', () => {
+    let errorSpy: jest.SpyInstance
+    let exitSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      errorSpy = jest.spyOn(console, 'error').mockReturnValue(undefined)
+      exitSpy = jest.spyOn(process, 'exit').mockReturnValue(undefined as never)
+    })
+
+    afterAll(() => {
+      errorSpy.mockRestore()
+      exitSpy.mockRestore()
+    })
+
+    it('exits with an error', () => {
+      initCommands({ ...mockArgs, applicationId: undefined })
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        'You must provide an application ID to use commands.',
+      )
+      expect(exitSpy).toHaveBeenCalledWith(1)
+
+      expect(buildSpy).toHaveBeenCalledWith(mockCommands)
+      expect(startRestClientSpy).not.toHaveBeenCalled()
+      expect(mockClient.on).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -4,7 +4,7 @@ import { BotCommand, Context } from '../types'
 import initCommands, { InitCommandsArgs } from './init'
 import * as buildModule from './utils/build'
 import * as handleCommandModule from './utils/handleCommand'
-import * as startRestClientModule from './utils/startRestClient'
+import * as registerCommandsModule from './utils/registerCommands'
 
 describe('initCommands', () => {
   beforeEach(jest.clearAllMocks)
@@ -31,8 +31,8 @@ describe('initCommands', () => {
     .spyOn(buildModule, 'default')
     .mockReturnValue(mockResolvedCommands)
 
-  const startRestClientSpy = jest
-    .spyOn(startRestClientModule, 'default')
+  const registerCommandsSpy = jest
+    .spyOn(registerCommandsModule, 'default')
     .mockReturnValue(undefined)
 
   describe('when the commands are successfully initialized', () => {
@@ -40,9 +40,9 @@ describe('initCommands', () => {
       initCommands(mockArgs)
     })
 
-    it('starts a REST client and subscribes to interactionCreate', () => {
+    it('registers the commands and subscribes to interactionCreate', () => {
       expect(buildSpy).toHaveBeenCalledWith(mockCommands)
-      expect(startRestClientSpy).toHaveBeenCalledWith({
+      expect(registerCommandsSpy).toHaveBeenCalledWith({
         applicationId: mockApplicationId,
         commands: mockResolvedCommands,
         token: mockToken,
@@ -112,7 +112,7 @@ describe('initCommands', () => {
       initCommands({ ...mockArgs, commands: [] })
 
       expect(buildSpy).toHaveBeenCalledWith([])
-      expect(startRestClientSpy).not.toHaveBeenCalled()
+      expect(registerCommandsSpy).not.toHaveBeenCalled()
       expect(mockClient.on).not.toHaveBeenCalled()
     })
 
@@ -120,7 +120,7 @@ describe('initCommands', () => {
       initCommands({ ...mockArgs, commands: [], applicationId: undefined })
 
       expect(buildSpy).toHaveBeenCalledWith([])
-      expect(startRestClientSpy).not.toHaveBeenCalled()
+      expect(registerCommandsSpy).not.toHaveBeenCalled()
       expect(mockClient.on).not.toHaveBeenCalled()
     })
   })
@@ -148,7 +148,7 @@ describe('initCommands', () => {
       expect(exitSpy).toHaveBeenCalledWith(1)
 
       expect(buildSpy).toHaveBeenCalledWith(mockCommands)
-      expect(startRestClientSpy).not.toHaveBeenCalled()
+      expect(registerCommandsSpy).not.toHaveBeenCalled()
       expect(mockClient.on).not.toHaveBeenCalled()
     })
   })

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -2,7 +2,7 @@ import { Client } from 'discord.js'
 import { BotCommand, Context, CustomContext } from '../types'
 import build from './utils/build'
 import handleCommand from './utils/handleCommand'
-import startRestClient from './utils/startRestClient'
+import registerCommands from './utils/registerCommands'
 
 export type InitCommandsArgs<C extends CustomContext> = {
   applicationId?: string
@@ -31,7 +31,7 @@ const initCommands = <C extends CustomContext>({
     return process.exit(1)
   }
 
-  startRestClient({
+  registerCommands({
     applicationId,
     commands: resolvedCommands,
     token,

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,0 +1,47 @@
+import { Client } from 'discord.js'
+import { BotCommand, Context, CustomContext } from '../types'
+import build from './utils/build'
+import handleCommand from './utils/handleCommand'
+import startRestClient from './utils/startRestClient'
+
+export type InitCommandsArgs<C extends CustomContext> = {
+  applicationId?: string
+  client: Client
+  commands: BotCommand<C>[]
+  context: Context<C>
+  token: string
+}
+
+const initCommands = <C extends CustomContext>({
+  applicationId,
+  client,
+  commands,
+  context,
+  token,
+}: InitCommandsArgs<C>) => {
+  const resolvedCommands = build(commands)
+
+  if (!resolvedCommands.length) {
+    return
+  }
+
+  if (!applicationId) {
+    console.error('You must provide an application ID to use commands.')
+
+    return process.exit(1)
+  }
+
+  startRestClient({
+    applicationId,
+    commands: resolvedCommands,
+    token,
+  })
+
+  client.on('interactionCreate', async (interaction) => {
+    if (!interaction.isCommand()) return
+
+    await handleCommand({ commands, context, interaction })
+  })
+}
+
+export default initCommands

--- a/src/commands/utils/build.test.ts
+++ b/src/commands/utils/build.test.ts
@@ -1,0 +1,54 @@
+import { BotCommand } from '../../types'
+import build from './build'
+
+const mockSlashCommandBuilder = {
+  setName: jest.fn().mockReturnThis(),
+  setDescription: jest.fn().mockReturnThis(),
+}
+
+jest.mock('@discordjs/builders', () => ({
+  SlashCommandBuilder: jest
+    .fn()
+    .mockImplementation(() => mockSlashCommandBuilder),
+}))
+
+describe('build', () => {
+  const mockCommandA = {
+    name: 'command-a',
+    description: 'command-a-desc',
+    handler: jest.fn(),
+  }
+
+  const mockCommandB = {
+    name: 'command-b',
+    description: 'command-b-desc',
+    handler: jest.fn(),
+  }
+
+  const mockCommands: BotCommand[] = [mockCommandA, mockCommandB]
+
+  it('returns a list of SlashCommandBuilders', () => {
+    expect(build(mockCommands)).toStrictEqual([
+      mockSlashCommandBuilder,
+      mockSlashCommandBuilder,
+    ])
+
+    expect(mockSlashCommandBuilder.setName).toHaveBeenNthCalledWith(
+      1,
+      mockCommandA.name,
+    )
+    expect(mockSlashCommandBuilder.setDescription).toHaveBeenNthCalledWith(
+      1,
+      mockCommandA.description,
+    )
+
+    expect(mockSlashCommandBuilder.setName).toHaveBeenNthCalledWith(
+      2,
+      mockCommandB.name,
+    )
+    expect(mockSlashCommandBuilder.setDescription).toHaveBeenNthCalledWith(
+      2,
+      mockCommandB.description,
+    )
+  })
+})

--- a/src/commands/utils/build.ts
+++ b/src/commands/utils/build.ts
@@ -1,0 +1,18 @@
+import { SlashCommandBuilder } from '@discordjs/builders'
+import { BotCommand, CustomContext } from '../../types'
+
+/**
+ * Builds a list of discord.js SlashCommands for a given list of BotCommands.
+ */
+const build = <C extends CustomContext>(
+  commands: BotCommand<C>[],
+): SlashCommandBuilder[] =>
+  commands.map(({ name, description }) => {
+    const cmd = new SlashCommandBuilder()
+      .setName(name)
+      .setDescription(description)
+
+    return cmd
+  })
+
+export default build

--- a/src/commands/utils/handleCommand.test.ts
+++ b/src/commands/utils/handleCommand.test.ts
@@ -1,0 +1,60 @@
+import { Client, CommandInteraction } from 'discord.js'
+import { BotCommand } from '../../types'
+import handleCommand from './handleCommand'
+
+describe('handleCommand', () => {
+  beforeEach(jest.clearAllMocks)
+
+  const mockCommandA = {
+    name: 'command-a',
+    description: 'command-a-desc',
+    handler: jest.fn(),
+  }
+
+  const mockCommandB = {
+    name: 'command-b',
+    description: 'command-b-desc',
+    handler: jest.fn(),
+  }
+
+  const mockCommands: BotCommand[] = [mockCommandA, mockCommandB]
+
+  const mockContext = {
+    client: jest.fn() as unknown as Client,
+    functions: [],
+    foo: 'bar',
+  }
+
+  it('should ignore the interaction if it does not match any of the commands', () => {
+    const mockInteraction = {
+      commandName: 'not-found',
+    } as CommandInteraction
+
+    handleCommand({
+      commands: mockCommands,
+      context: mockContext,
+      interaction: mockInteraction,
+    })
+
+    expect(mockCommandA.handler).not.toHaveBeenCalled()
+    expect(mockCommandB.handler).not.toHaveBeenCalled()
+  })
+
+  it('should call the handler of the command that matches the interaction', () => {
+    const mockInteraction = {
+      commandName: mockCommandB.name,
+    } as CommandInteraction
+
+    handleCommand({
+      commands: mockCommands,
+      context: mockContext,
+      interaction: mockInteraction,
+    })
+
+    expect(mockCommandA.handler).not.toHaveBeenCalled()
+    expect(mockCommandB.handler).toHaveBeenCalledWith({
+      context: mockContext,
+      interaction: mockInteraction,
+    })
+  })
+})

--- a/src/commands/utils/handleCommand.ts
+++ b/src/commands/utils/handleCommand.ts
@@ -1,0 +1,24 @@
+import { CommandInteraction } from 'discord.js'
+import { BotCommand, Context, CustomContext } from '../../types'
+
+type HandleCommandArgs<C extends CustomContext> = {
+  commands: BotCommand<C>[]
+  context: Context<C>
+  interaction: CommandInteraction
+}
+
+const handleCommand = async <C extends CustomContext = {}>({
+  commands,
+  context,
+  interaction,
+}: HandleCommandArgs<C>): Promise<void> => {
+  const command = commands.find(({ name }) => interaction.commandName === name)
+
+  if (!command) {
+    return
+  }
+
+  await command.handler({ context, interaction })
+}
+
+export default handleCommand

--- a/src/commands/utils/registerCommands.test.ts
+++ b/src/commands/utils/registerCommands.test.ts
@@ -1,7 +1,7 @@
 import { SlashCommandBuilder } from '@discordjs/builders'
 import { REST } from '@discordjs/rest'
 import { Routes } from 'discord-api-types/v9'
-import startRestClient from './startRestClient'
+import registerCommands from './registerCommands'
 
 const mockRest = {
   setToken: jest.fn().mockReturnThis(),
@@ -12,13 +12,13 @@ jest.mock('@discordjs/rest', () => ({
   REST: jest.fn().mockImplementation(() => mockRest),
 }))
 
-describe('startRestClient', () => {
+describe('registerCommands', () => {
   const mockCommands = ['botCommand' as unknown as SlashCommandBuilder]
   const mockToken = 'mock-token'
   const mockApplicationId = 'mock-application-id'
 
-  it('starts a REST client and registers the commands', () => {
-    startRestClient({
+  it('registers the commands', () => {
+    registerCommands({
       applicationId: mockApplicationId,
       commands: mockCommands,
       token: mockToken,

--- a/src/commands/utils/registerCommands.ts
+++ b/src/commands/utils/registerCommands.ts
@@ -2,20 +2,20 @@ import { SlashCommandBuilder } from '@discordjs/builders'
 import { REST } from '@discordjs/rest'
 import { Routes } from 'discord-api-types/v9'
 
-type StartRestClientArgs = {
+type RegisterCommandsArgs = {
   applicationId: string
   commands: SlashCommandBuilder[]
   token: string
 }
 
 /**
- * Starts a REST client and registers the application commands.
+ * Registers the given application commands with Discord API.
  */
-const startRestClient = ({
+const registerCommands = ({
   applicationId,
   commands,
   token,
-}: StartRestClientArgs) => {
+}: RegisterCommandsArgs) => {
   const rest = new REST({ version: '10' }).setToken(token)
 
   rest
@@ -23,4 +23,4 @@ const startRestClient = ({
     .catch(console.error)
 }
 
-export default startRestClient
+export default registerCommands

--- a/src/commands/utils/startRestClient.test.ts
+++ b/src/commands/utils/startRestClient.test.ts
@@ -1,0 +1,34 @@
+import { SlashCommandBuilder } from '@discordjs/builders'
+import { REST } from '@discordjs/rest'
+import { Routes } from 'discord-api-types/v9'
+import startRestClient from './startRestClient'
+
+const mockRest = {
+  setToken: jest.fn().mockReturnThis(),
+  put: jest.fn().mockResolvedValue(undefined),
+}
+
+jest.mock('@discordjs/rest', () => ({
+  REST: jest.fn().mockImplementation(() => mockRest),
+}))
+
+describe('startRestClient', () => {
+  const mockCommands = ['botCommand' as unknown as SlashCommandBuilder]
+  const mockToken = 'mock-token'
+  const mockApplicationId = 'mock-application-id'
+
+  it('starts a REST client and registers the commands', () => {
+    startRestClient({
+      applicationId: mockApplicationId,
+      commands: mockCommands,
+      token: mockToken,
+    })
+
+    expect(REST).toHaveBeenCalledWith({ version: '10' })
+    expect(mockRest.setToken).toHaveBeenCalledWith(mockToken)
+    expect(mockRest.put).toHaveBeenCalledWith(
+      Routes.applicationCommands(mockApplicationId),
+      { body: mockCommands },
+    )
+  })
+})

--- a/src/commands/utils/startRestClient.ts
+++ b/src/commands/utils/startRestClient.ts
@@ -1,0 +1,26 @@
+import { SlashCommandBuilder } from '@discordjs/builders'
+import { REST } from '@discordjs/rest'
+import { Routes } from 'discord-api-types/v9'
+
+type StartRestClientArgs = {
+  applicationId: string
+  commands: SlashCommandBuilder[]
+  token: string
+}
+
+/**
+ * Starts a REST client and registers the application commands.
+ */
+const startRestClient = ({
+  applicationId,
+  commands,
+  token,
+}: StartRestClientArgs) => {
+  const rest = new REST({ version: '10' }).setToken(token)
+
+  rest
+    .put(Routes.applicationCommands(applicationId), { body: commands })
+    .catch(console.error)
+}
+
+export default startRestClient

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,4 +1,5 @@
 import Discord, { ClientOptions, Intents } from 'discord.js'
+import initCommands from './commands/init'
 import getHelpFunction from './functions/help'
 import { BotFunction, Context, CustomContext, InitOptions } from './types'
 import handleEvent from './utils/handleEvent'
@@ -16,10 +17,13 @@ export const init = <C extends CustomContext = {}>(
   options: InitOptions<C>,
 ): Discord.Client => {
   const {
+    applicationId,
+    commands = [],
     context = {} as C,
     functions,
     helpCommand,
     intents = DEFAULT_INTENTS,
+    token,
   } = options
 
   if (functions.some((fn) => fn.name?.includes(' '))) {
@@ -62,6 +66,16 @@ export const init = <C extends CustomContext = {}>(
   Object.entries(eventFunctionsMap).forEach(([event, eventFns]) => {
     client.on(event, (...args) => handleEvent(args, eventFns, resolvedContext))
   })
+
+  initCommands<C>({
+    applicationId,
+    client,
+    commands,
+    context: resolvedContext,
+    token,
+  })
+
+  client.login(token)
 
   return client
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,29 @@
-import Discord, { ClientEvents, ClientOptions } from 'discord.js'
+import Discord, {
+  ClientEvents,
+  ClientOptions,
+  CommandInteraction,
+} from 'discord.js'
 
 /** Initialization options for your cordless bot */
 export type InitOptions<C extends CustomContext = {}> = {
+  /** The commands used by your bot. */
+  commands?: BotCommand<C>[]
   /** The functions used by your bot */
   functions: BotFunction<any, C>[] // eslint-disable-line @typescript-eslint/no-explicit-any
-  /** A custom context object which will extend the context passed to your functions' callbacks and conditions */
+  /**
+   * Your bot token.
+   *
+   * @see https://discordjs.guide/preparations/setting-up-a-bot-application.html#your-bot-s-token
+   */
+  token: string
+  /**
+   * Your application ID.
+   * Required to register commands.
+   *
+   * @see https://discordjs.guide/creating-your-bot/creating-commands.html#registering-commands
+   */
+  applicationId?: string
+  /** A custom context object which will extend the context passed to your commands and functions */
   context?: C
   /**
    * Override the default Gateway Intents of the discord.js client.
@@ -25,6 +44,17 @@ export type InitOptions<C extends CustomContext = {}> = {
    * - !help <function-name> (shows a description and usage instructions for the given function)
    */
   helpCommand?: string
+}
+
+export type BotCommand<C extends CustomContext = {}> = {
+  name: string
+  description: string
+  handler: (args: BotCommandHandlerArgs<C>) => void | Promise<void>
+}
+
+export type BotCommandHandlerArgs<C extends CustomContext = {}> = {
+  interaction: CommandInteraction
+  context: Context<C>
 }
 
 export type BotFunction<

--- a/yarn.lock
+++ b/yarn.lock
@@ -357,10 +357,34 @@
     ts-mixer "^6.0.1"
     tslib "^2.4.0"
 
+"@discordjs/builders@^0.15.0":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@discordjs/builders/-/builders-0.15.0.tgz#f76318f2de0b057c21bb25bb010ef2317039793d"
+  integrity sha512-w1UfCPzx2iKycn6qh/f0c+PcDpcTHzHr7TXALXu/a4gKHGamiSg3lP8GhYswweSJk/Q5cbFLHZUsnoY3MVKNAg==
+  dependencies:
+    "@sapphire/shapeshift" "^3.1.0"
+    "@sindresorhus/is" "^4.6.0"
+    discord-api-types "^0.33.3"
+    fast-deep-equal "^3.1.3"
+    ts-mixer "^6.0.1"
+    tslib "^2.4.0"
+
 "@discordjs/collection@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@discordjs/collection/-/collection-0.7.0.tgz#1a6c00198b744ba2b73a64442145da637ac073b8"
   integrity sha512-R5i8Wb8kIcBAFEPLLf7LVBQKBDYUL+ekb23sOgpkpyGT+V4P7V83wTxcsqmX+PbqHt4cEHn053uMWfRqh/Z/nA==
+
+"@discordjs/rest@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@discordjs/rest/-/rest-0.5.0.tgz#dc5bd68e33bf8dd1cf08cf3c55b2901deb92eb5d"
+  integrity sha512-S4E1YNz1UxgUfMPpMeqzPPkCfXE877zOsvKM5WEmwIhcpz1PQV7lzqlEOuz194UuwOJLLjQFBgQELnQfCX9UfA==
+  dependencies:
+    "@discordjs/collection" "^0.7.0"
+    "@sapphire/async-queue" "^1.3.1"
+    "@sapphire/snowflake" "^3.2.2"
+    discord-api-types "^0.33.3"
+    tslib "^2.4.0"
+    undici "^5.4.0"
 
 "@eslint/eslintrc@^1.3.0":
   version "1.3.0"
@@ -986,6 +1010,11 @@
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@sapphire/shapeshift/-/shapeshift-3.4.0.tgz#0dab2397276612bc82413d38ebfa4f4e4e0fa9be"
   integrity sha512-uV+vErdfbxCgnjgcwkPDADlyS40I20L57YPy254LKbRNfLCg4/ymy510aNSGhLhq/dpNU0s1fQnTbI2YAetzsA==
+
+"@sapphire/snowflake@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@sapphire/snowflake/-/snowflake-3.2.2.tgz#faacdc1b5f7c43145a71eddba917de2b707ef780"
+  integrity sha512-ula2O0kpSZtX9rKXNeQMrHwNd7E4jPDJYUXmEGTFdMRfyfMw+FPyh04oKMjAiDuOi64bYgVkOV3MjK+loImFhQ==
 
 "@semantic-release/changelog@^6.0.1":
   version "6.0.1"
@@ -2291,6 +2320,11 @@ discord-api-types@^0.33.3:
   version "0.33.5"
   resolved "https://registry.yarnpkg.com/discord-api-types/-/discord-api-types-0.33.5.tgz#6548b70520f7b944c60984dca4ab58654d664a12"
   integrity sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg==
+
+discord-api-types@^0.36.2:
+  version "0.36.2"
+  resolved "https://registry.yarnpkg.com/discord-api-types/-/discord-api-types-0.36.2.tgz#2362bc544837be965ec99a5919f900c9699a7028"
+  integrity sha512-TunPAvzwneK/m5fr4hxH3bMsrtI22nr9yjfHyo5NBGMjpsAauGNiGCmwoFf0oO3jSd2mZiKUvZwCKDaB166u2Q==
 
 discord.js@^13.8.1:
   version "13.8.1"
@@ -6090,6 +6124,11 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+undici@^5.4.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.7.0.tgz#979f89229c01505573cb274d0e11ea8d82b4004f"
+  integrity sha512-ORgxwDkiPS+gK2VxE7iyVeR7JliVn5DqhZ4LgQqYLBXsuK+lwOEmnJ66dhvlpLM0tC3fC7eYF1Bti2frbw2eAA==
 
 unique-filename@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
This PR adds [Application Commands](https://discord.com/developers/docs/interactions/application-commands) to cordless, allowing bots to register commands and react to them. For now, only basic interactions are possible. Future PRs will add additional features like accepting options, responding with interactive buttons, and more.

---

#### Basic Commands usage

```ts
const ping: BotCommand = {
  name: "ping",
  description: "Replies to your ping.",
  handler: ({ interaction }) =>
    interaction.reply({
      content: "Pong!",
    }),
};

init({
  applicationId: process.env.APPLICATION_ID,
  commands: [ping],
  functions: [],
  token: process.env.BOT_TOKEN || "",
});

```

**Note**: your bot's application ID can be found in the Discord developer portal. It's only required if you are using commands.

---

#### Breaking changes

- The bot token must now be passed into the initialization method (even if you are not using commands)
- The client now logs in automatically, so you should not call `.login(token)` anymore

Previous:

```ts
init({ functions: [...] }).login(process.env.BOT_TOKEN)
```

New:
```ts
init({
  functions: [...],
  token: process.env.BOT_TOKEN || "",
});
```