### PR TITLE
feat(client): Modify initialization behavior, prevent the requirement to pass an applicationId

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,16 +81,14 @@ See: [docs/help-command.md](docs/help-command.md)
 
 #### Using discord.js features
 
-The `init` method returns a [discord.js Client](https://discord.js.org/#/docs/main/stable/class/Client).
+The `init` method returns a logged-in [discord.js Client](https://discord.js.org/#/docs/main/stable/class/Client).
 
 ```ts
-const client = init({
+const client = await init({
   // ...
 })
 
-client.on('ready', () => {
-  console.log(`Logged in as ${client.user?.tag}!`)
-})
+console.log(`Logged in as ${client.user.tag}!`)
 ```
 
 See [discord.js documentation](https://discord.js.org/#/docs) for more information about using the client.

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -7,19 +7,15 @@ dotenv.config()
 export const setupClients = async <T extends CustomContext>(
   options: Omit<InitOptions<T>, 'token'>,
 ): Promise<{
-  cordlessClient: Client
-  userClient: Client
+  cordlessClient: Client<true>
+  userClient: Client<true>
   e2eChannel: TextBasedChannel
   sendMessageAndWaitForIt: (content: string) => Promise<Message>
 }> => {
   // Login as the cordless client
-  const cordlessClient = init({
+  const cordlessClient = await init({
     ...options,
     token: process.env.E2E_CLIENT_TOKEN || '',
-  })
-
-  await new Promise<void>((resolve) => {
-    cordlessClient.on('ready', () => resolve())
   })
 
   // Login as the test user
@@ -28,7 +24,7 @@ export const setupClients = async <T extends CustomContext>(
   })
 
   await new Promise<void>((resolve) => {
-    userClient.on('ready', () => resolve())
+    userClient.once('ready', () => resolve())
 
     userClient.login(process.env.E2E_USER_TOKEN)
   })

--- a/src/__snapshots__/init.test.ts.snap
+++ b/src/__snapshots__/init.test.ts.snap
@@ -23,18 +23,8 @@ Array [
     ],
     Object {
       "client": Object {
-        "login": [MockFunction] {
-          "calls": Array [
-            Array [
-              "mock-token",
-            ],
-          ],
-          "results": Array [
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-          ],
+        "application": Object {
+          "id": "mock-application-id",
         },
         "on": [MockFunction] {
           "calls": Array [
@@ -122,18 +112,8 @@ Array [
     ],
     Object {
       "client": Object {
-        "login": [MockFunction] {
-          "calls": Array [
-            Array [
-              "mock-token",
-            ],
-          ],
-          "results": Array [
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-          ],
+        "application": Object {
+          "id": "mock-application-id",
         },
         "on": [MockFunction] {
           "calls": Array [
@@ -215,18 +195,8 @@ Array [
     ],
     Object {
       "client": Object {
-        "login": [MockFunction] {
-          "calls": Array [
-            Array [
-              "mock-token",
-            ],
-          ],
-          "results": Array [
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-          ],
+        "application": Object {
+          "id": "mock-application-id",
         },
         "on": [MockFunction] {
           "calls": Array [

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -10,13 +10,15 @@ describe('initCommands', () => {
   beforeEach(jest.clearAllMocks)
 
   const mockApplicationId = 'mock-application-id'
-  const mockClient: Client = { on: jest.fn() } as unknown as Client
+  const mockClient: Client<true> = {
+    on: jest.fn(),
+    application: { id: mockApplicationId },
+  } as unknown as Client<true>
   const mockCommands: BotCommand[] = ['botCommand' as unknown as BotCommand]
   const mockContext: Context = { client: mockClient, functions: [] }
   const mockToken = 'mock-token'
 
   const mockArgs: InitCommandsArgs<{}> = {
-    applicationId: mockApplicationId,
     client: mockClient,
     commands: mockCommands,
     context: mockContext,
@@ -112,42 +114,6 @@ describe('initCommands', () => {
       initCommands({ ...mockArgs, commands: [] })
 
       expect(buildSpy).toHaveBeenCalledWith([])
-      expect(registerCommandsSpy).not.toHaveBeenCalled()
-      expect(mockClient.on).not.toHaveBeenCalled()
-    })
-
-    it('does nothing even when applicationId was not provided', () => {
-      initCommands({ ...mockArgs, commands: [], applicationId: undefined })
-
-      expect(buildSpy).toHaveBeenCalledWith([])
-      expect(registerCommandsSpy).not.toHaveBeenCalled()
-      expect(mockClient.on).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('when there are commands but the applicationId was not provided', () => {
-    let errorSpy: jest.SpyInstance
-    let exitSpy: jest.SpyInstance
-
-    beforeEach(() => {
-      errorSpy = jest.spyOn(console, 'error').mockReturnValue(undefined)
-      exitSpy = jest.spyOn(process, 'exit').mockReturnValue(undefined as never)
-    })
-
-    afterAll(() => {
-      errorSpy.mockRestore()
-      exitSpy.mockRestore()
-    })
-
-    it('exits with an error', () => {
-      initCommands({ ...mockArgs, applicationId: undefined })
-
-      expect(errorSpy).toHaveBeenCalledWith(
-        'You must provide an application ID to use commands.',
-      )
-      expect(exitSpy).toHaveBeenCalledWith(1)
-
-      expect(buildSpy).toHaveBeenCalledWith(mockCommands)
       expect(registerCommandsSpy).not.toHaveBeenCalled()
       expect(mockClient.on).not.toHaveBeenCalled()
     })

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -5,15 +5,13 @@ import handleCommand from './utils/handleCommand'
 import registerCommands from './utils/registerCommands'
 
 export type InitCommandsArgs<C extends CustomContext> = {
-  applicationId?: string
-  client: Client
+  client: Client<true>
   commands: BotCommand<C>[]
   context: Context<C>
   token: string
 }
 
 const initCommands = <C extends CustomContext>({
-  applicationId,
   client,
   commands,
   context,
@@ -25,14 +23,8 @@ const initCommands = <C extends CustomContext>({
     return
   }
 
-  if (!applicationId) {
-    console.error('You must provide an application ID to use commands.')
-
-    return process.exit(1)
-  }
-
   registerCommands({
-    applicationId,
+    applicationId: client.application.id,
     commands: resolvedCommands,
     token,
   })

--- a/src/init.ts
+++ b/src/init.ts
@@ -13,11 +13,10 @@ const DEFAULT_INTENTS: ClientOptions['intents'] = [
  * Initializes a cordless bot with the given options.
  * Returns a discord.js client.
  */
-export const init = <C extends CustomContext = {}>(
+export const init = async <C extends CustomContext = {}>(
   options: InitOptions<C>,
-): Discord.Client => {
+): Promise<Discord.Client<true>> => {
   const {
-    applicationId,
     commands = [],
     context = {} as C,
     functions,
@@ -31,9 +30,15 @@ export const init = <C extends CustomContext = {}>(
   }
 
   //
-  // Initialize Discord.js client
+  // Initialize Discord.js client and login
   //
-  const client = new Discord.Client({ intents })
+  const client = await new Promise<Discord.Client<true>>((resolve) => {
+    const c = new Discord.Client({ intents })
+
+    c.once('ready', resolve)
+
+    c.login(token)
+  })
 
   //
   // Resolve functions and context
@@ -68,14 +73,11 @@ export const init = <C extends CustomContext = {}>(
   })
 
   initCommands<C>({
-    applicationId,
     client,
     commands,
     context: resolvedContext,
     token,
   })
-
-  client.login(token)
 
   return client
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,13 +19,6 @@ export type InitOptions<C extends CustomContext = {}> = {
    * @see https://discordjs.guide/preparations/setting-up-a-bot-application.html#your-bot-s-token
    */
   token: string
-  /**
-   * Your application ID.
-   * Required to register commands.
-   *
-   * @see https://discordjs.guide/creating-your-bot/creating-commands.html#registering-commands
-   */
-  applicationId?: string
   /** A custom context object which will extend the context passed to your commands and functions */
   context?: C
   /**
@@ -153,6 +146,6 @@ export type BotFunction<
 export type CustomContext = Record<string, any>
 
 export type Context<C extends CustomContext = {}> = {
-  client: Discord.Client
+  client: Discord.Client<true>
   functions: BotFunction<any, C>[] // eslint-disable-line @typescript-eslint/no-explicit-any
 } & C


### PR DESCRIPTION
This PR modifies the behavior of calling the `init()` method. It now fully logs in to the client and returns the logged-in client. That means it's no longer needed to pass an `applicationId` when using commands, because the application ID is retrieved from the logged-in client.

Previously:

```ts
init({
  applicationId: '...',
  commands: [...],
  token: '...',
})
```

Now:

```ts
init({
  commands: [...],
  token: '...',
})
```

---

#### Breaking changes

The `init()` method now returns a `Promise<Discord.Client<true>>`.

Previously:

```ts
const client = init({
  // ...
})

client.on('ready', () => {
  console.log(`Logged in as ${client.user?.tag}!`)
})
```

Now:

```ts
const client = await init({
  // ...
})

console.log(`Logged in as ${client.user.tag}!`)
```