### PR TITLE
feat(commands): Allow commands to receive subcommands

### DIFF
--- a/src/commands/utils/addOptionsToCmd.ts
+++ b/src/commands/utils/addOptionsToCmd.ts
@@ -1,11 +1,14 @@
-import { SlashCommandBuilder } from '@discordjs/builders'
+import {
+  SlashCommandBuilder,
+  SlashCommandSubcommandBuilder,
+} from '@discordjs/builders'
 import { BotCommandOption } from '../../types'
 
 /**
  * Adds a list of options to a SlashCommand
  */
 const addOptionsToCmd = (
-  cmd: SlashCommandBuilder,
+  cmd: SlashCommandBuilder | SlashCommandSubcommandBuilder,
   options: BotCommandOption[],
 ) => {
   options.forEach((option) => {

--- a/src/commands/utils/build.ts
+++ b/src/commands/utils/build.ts
@@ -1,6 +1,7 @@
 import { SlashCommandBuilder } from '@discordjs/builders'
 import { BotCommand, CustomContext } from '../../types'
 import addOptionsToCmd from './addOptionsToCmd'
+import isCommandWithHandler from './isCommandWithHandler'
 
 /**
  * Builds a list of discord.js SlashCommands for a given list of BotCommands.
@@ -8,12 +9,34 @@ import addOptionsToCmd from './addOptionsToCmd'
 const build = <C extends CustomContext>(
   commands: BotCommand<C>[],
 ): SlashCommandBuilder[] =>
-  commands.map(({ name, description, options = [] }) => {
+  commands.map((command) => {
+    const { name, description = 'No description' } = command
+
     const cmd = new SlashCommandBuilder()
       .setName(name)
       .setDescription(description)
 
-    addOptionsToCmd(cmd, options)
+    if (isCommandWithHandler(command)) {
+      const { options = [] } = command
+
+      addOptionsToCmd(cmd, options)
+    } else {
+      command.subcommands.forEach((subcommand) => {
+        const {
+          name,
+          description = 'No description',
+          options = [],
+        } = subcommand
+
+        cmd.addSubcommand((s) => {
+          s.setName(name).setDescription(description)
+
+          addOptionsToCmd(s, options)
+
+          return s
+        })
+      })
+    }
 
     return cmd
   })

--- a/src/commands/utils/handleCommand.test.ts
+++ b/src/commands/utils/handleCommand.test.ts
@@ -88,7 +88,7 @@ describe('handleCommand', () => {
   })
 
   describe('when a BotCommandWithSubcommands matches the interaction', () => {
-    describe('when none of the subcommands matche the interaction', () => {
+    describe('when none of the subcommands match the interaction', () => {
       const mockInteraction = {
         commandName: mockCommandWithSubcommands.name,
         options: {

--- a/src/commands/utils/handleCommand.test.ts
+++ b/src/commands/utils/handleCommand.test.ts
@@ -1,23 +1,44 @@
 import { Client, CommandInteraction } from 'discord.js'
-import { BotCommand } from '../../types'
+import {
+  BotCommand,
+  BotCommandWithHandler,
+  BotCommandWithSubcommands,
+} from '../../types'
 import handleCommand from './handleCommand'
 
 describe('handleCommand', () => {
   beforeEach(jest.clearAllMocks)
 
-  const mockCommandA = {
+  const mockCommandWithHandlerA: BotCommandWithHandler = {
     name: 'command-a',
-    description: 'command-a-desc',
     handler: jest.fn(),
   }
 
-  const mockCommandB = {
+  const mockCommandWithHandlerB: BotCommandWithHandler = {
     name: 'command-b',
-    description: 'command-b-desc',
     handler: jest.fn(),
   }
 
-  const mockCommands: BotCommand[] = [mockCommandA, mockCommandB]
+  const mockSubcommandA: BotCommandWithHandler = {
+    name: 'subcommand-a',
+    handler: jest.fn(),
+  }
+
+  const mockSubcommandB: BotCommandWithHandler = {
+    name: 'subcommand-b',
+    handler: jest.fn(),
+  }
+
+  const mockCommandWithSubcommands: BotCommandWithSubcommands = {
+    name: 'command-c',
+    subcommands: [mockSubcommandA, mockSubcommandB],
+  }
+
+  const mockCommands: BotCommand[] = [
+    mockCommandWithHandlerA,
+    mockCommandWithHandlerB,
+    mockCommandWithSubcommands,
+  ]
 
   const mockContext = {
     client: jest.fn() as unknown as Client,
@@ -25,36 +46,97 @@ describe('handleCommand', () => {
     foo: 'bar',
   }
 
-  it('should ignore the interaction if it does not match any of the commands', () => {
+  describe('when none of the commands match the interaction', () => {
     const mockInteraction = {
       commandName: 'not-found',
     } as CommandInteraction
 
-    handleCommand({
-      commands: mockCommands,
-      context: mockContext,
-      interaction: mockInteraction,
-    })
+    it('should ignore the interaction', () => {
+      handleCommand({
+        commands: mockCommands,
+        context: mockContext,
+        interaction: mockInteraction,
+      })
 
-    expect(mockCommandA.handler).not.toHaveBeenCalled()
-    expect(mockCommandB.handler).not.toHaveBeenCalled()
+      expect(mockCommandWithHandlerA.handler).not.toHaveBeenCalled()
+      expect(mockCommandWithHandlerB.handler).not.toHaveBeenCalled()
+      expect(mockSubcommandA.handler).not.toHaveBeenCalled()
+      expect(mockSubcommandB.handler).not.toHaveBeenCalled()
+    })
   })
 
-  it('should call the handler of the command that matches the interaction', () => {
+  describe('when a BotCommandWithHandler matches the interaction', () => {
     const mockInteraction = {
-      commandName: mockCommandB.name,
+      commandName: mockCommandWithHandlerB.name,
     } as CommandInteraction
 
-    handleCommand({
-      commands: mockCommands,
-      context: mockContext,
-      interaction: mockInteraction,
+    it('should call the handler of the matching command', () => {
+      handleCommand({
+        commands: mockCommands,
+        context: mockContext,
+        interaction: mockInteraction,
+      })
+
+      expect(mockCommandWithHandlerA.handler).not.toHaveBeenCalled()
+      expect(mockCommandWithHandlerB.handler).toHaveBeenCalledWith({
+        context: mockContext,
+        interaction: mockInteraction,
+      })
+      expect(mockSubcommandA.handler).not.toHaveBeenCalled()
+      expect(mockSubcommandB.handler).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when a BotCommandWithSubcommands matches the interaction', () => {
+    describe('when none of the subcommands matche the interaction', () => {
+      const mockInteraction = {
+        commandName: mockCommandWithSubcommands.name,
+        options: {
+          getSubcommand: jest.fn().mockReturnValue('not-found'),
+        },
+      } as unknown as CommandInteraction
+
+      it('should ignore the interaction', () => {
+        handleCommand({
+          commands: mockCommands,
+          context: mockContext,
+          interaction: mockInteraction,
+        })
+
+        expect(mockCommandWithHandlerA.handler).not.toHaveBeenCalled()
+        expect(mockCommandWithHandlerB.handler).not.toHaveBeenCalled()
+        expect(mockSubcommandA.handler).not.toHaveBeenCalled()
+        expect(mockSubcommandB.handler).not.toHaveBeenCalled()
+
+        expect(mockInteraction.options.getSubcommand).toHaveBeenCalled()
+      })
     })
 
-    expect(mockCommandA.handler).not.toHaveBeenCalled()
-    expect(mockCommandB.handler).toHaveBeenCalledWith({
-      context: mockContext,
-      interaction: mockInteraction,
+    describe('when a subcommand matches the interaction', () => {
+      const mockInteraction = {
+        commandName: mockCommandWithSubcommands.name,
+        options: {
+          getSubcommand: jest.fn().mockReturnValue(mockSubcommandB.name),
+        },
+      } as unknown as CommandInteraction
+
+      it('should call the handler of the matching subcommand', () => {
+        handleCommand({
+          commands: mockCommands,
+          context: mockContext,
+          interaction: mockInteraction,
+        })
+
+        expect(mockCommandWithHandlerA.handler).not.toHaveBeenCalled()
+        expect(mockCommandWithHandlerB.handler).not.toHaveBeenCalled()
+        expect(mockSubcommandA.handler).not.toHaveBeenCalled()
+        expect(mockSubcommandB.handler).toHaveBeenCalledWith({
+          context: mockContext,
+          interaction: mockInteraction,
+        })
+
+        expect(mockInteraction.options.getSubcommand).toHaveBeenCalled()
+      })
     })
   })
 })

--- a/src/commands/utils/handleCommand.ts
+++ b/src/commands/utils/handleCommand.ts
@@ -1,5 +1,6 @@
 import { CommandInteraction } from 'discord.js'
 import { BotCommand, Context, CustomContext } from '../../types'
+import isCommandWithHandler from './isCommandWithHandler'
 
 type HandleCommandArgs<C extends CustomContext> = {
   commands: BotCommand<C>[]
@@ -18,7 +19,21 @@ const handleCommand = async <C extends CustomContext = {}>({
     return
   }
 
-  await command.handler({ context, interaction })
+  if (isCommandWithHandler(command)) {
+    return command.handler({ context, interaction })
+  }
+
+  const subcommandName = interaction.options.getSubcommand()
+
+  const subcommand = command.subcommands.find(
+    ({ name }) => subcommandName === name,
+  )
+
+  if (!subcommand) {
+    return
+  }
+
+  return subcommand.handler({ context, interaction })
 }
 
 export default handleCommand

--- a/src/commands/utils/isCommandWithHandler.test.ts
+++ b/src/commands/utils/isCommandWithHandler.test.ts
@@ -1,0 +1,22 @@
+import { BotCommandWithHandler, BotCommandWithSubcommands } from '../../types'
+import isCommandWithHandler from './isCommandWithHandler'
+
+describe('isCommandWithHandler', () => {
+  const mockBotCommandWithHandler: BotCommandWithHandler = {
+    name: 'mock-command-with-handler',
+    handler: () => undefined,
+  }
+
+  const mockBotCommandWithSubcommands: BotCommandWithSubcommands = {
+    name: 'mock-command-with-handler',
+    subcommands: [],
+  }
+
+  it('returns true when the given BotCommand is a BotCommandWithHandler', () => {
+    expect(isCommandWithHandler(mockBotCommandWithHandler)).toBe(true)
+  })
+
+  it('returns false when the given BotCommand is not a BotCommandWithHandler', () => {
+    expect(isCommandWithHandler(mockBotCommandWithSubcommands)).toBe(false)
+  })
+})

--- a/src/commands/utils/isCommandWithHandler.test.ts
+++ b/src/commands/utils/isCommandWithHandler.test.ts
@@ -8,7 +8,7 @@ describe('isCommandWithHandler', () => {
   }
 
   const mockBotCommandWithSubcommands: BotCommandWithSubcommands = {
-    name: 'mock-command-with-handler',
+    name: 'mock-command-with-subcommands',
     subcommands: [],
   }
 

--- a/src/commands/utils/isCommandWithHandler.ts
+++ b/src/commands/utils/isCommandWithHandler.ts
@@ -1,0 +1,11 @@
+import { BotCommand, BotCommandWithHandler, CustomContext } from '../../types'
+
+/**
+ * Type guard - returns true if the given BotCommand is a BotCommandWithHandler
+ */
+const isCommandWithHandler = <C extends CustomContext>(
+  command: BotCommand<C>,
+): command is BotCommandWithHandler<C> =>
+  Object.prototype.hasOwnProperty.call(command, 'handler')
+
+export default isCommandWithHandler

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,11 +42,27 @@ export type InitOptions<C extends CustomContext = {}> = {
   helpCommand?: string
 }
 
-export type BotCommand<C extends CustomContext = {}> = {
-  name: string
-  description: string
+export type BotCommand<C extends CustomContext = {}> =
+  | BotCommandWithHandler<C>
+  | BotCommandWithSubcommands<C>
+
+export interface BotCommandWithHandler<C extends CustomContext = {}>
+  extends BotCommandBase {
   handler: (args: BotCommandHandlerArgs<C>) => void | Promise<void>
   options?: BotCommandOption[]
+  subcommands?: never
+}
+
+export interface BotCommandWithSubcommands<C extends CustomContext = {}>
+  extends BotCommandBase {
+  subcommands: BotCommandWithHandler<C>[]
+  handler?: never
+  options?: never
+}
+
+type BotCommandBase = {
+  name: string
+  description?: string
 }
 
 export type BotCommandHandlerArgs<C extends CustomContext = {}> = {


### PR DESCRIPTION
This PR implements passing a list of subcommands to commands. A command can now either be a `BotCommandWithHandler` (as before) or a `BotCommandWithSubcommands` (new).

A `BotCommandWithSubcommands` must have an array of `subcommands: BotCommandWithHandler[]`.

In other words, subcommands cannot be nested more than one level deep (according to the Discord API requirements).

See: https://discord.com/developers/docs/interactions/application-commands#subcommands-and-subcommand-groups

---

#### Basic example

This adds a `/define` commands with two subcommands, `dictionary` and `urban`.
Usage: `/define dictionary <input>` or `/define urban <input>`.

```ts
const dictionary: BotCommand = {
  name: "dictionary",
  description: "Get the dictionary definition of a word.",
  options: [
    {
      type: "STRING",
      name: "input",
      required: true,
    },
  ],
  handler: async ({ interaction }) => {
    const input = interaction.options.getString("input", true);

    const result = await (
      await fetch(`https://api.dictionaryapi.dev/api/v2/entries/en/${input}`)
    ).json();

    interaction.reply(result[0].meanings[0].definitions[0].definition);
  },
};

const urban: BotCommand = {
  name: "urban",
  description: "Get the urbandictionary definition of a word.",
  options: [
    {
      type: "STRING",
      name: "input",
      required: true,
    },
  ],
  handler: async ({ interaction }) => {
    const input = interaction.options.getString("input", true);

    const result = await (
      await fetch(`https://api.urbandictionary.com/v0/define?term=${input}`)
    ).json();

    interaction.reply(result.list[0].definition);
  },
};

const define: BotCommand = {
  name: "define",
  subcommands: [dictionary, urban],
};

init({
  commands: [define],
  functions: [],
  token: process.env.BOT_TOKEN!,
});
```