### PR TITLE
update: reduce wait time still fix flakiness

### DIFF
--- a/e2e/setupTests.ts
+++ b/e2e/setupTests.ts
@@ -4,7 +4,7 @@
  * Otherwise, the client might fail to login.
  */
 beforeEach(async () => {
-  await new Promise<void>((resolve) => setTimeout(resolve, 2000))
+  await new Promise<void>((resolve) => setTimeout(resolve, 1024))
 })
 
 jest.setTimeout(30000)


### PR DESCRIPTION
Hello! 
Our team is investigating the impact of waiting time on flaky testing in asynchronous issues. We use your project and test code as one of our research data cases. Our experiments and test data have demonstrated that if the waiting time in the current test file is adjusted from 2000ms to 1024ms, it can still guarantee the success of all 100 rerun tests, and can also mitigate the running time of test files to a certain extent.

The new waiting time can alleviate flakiness while saving test execution time compared to the original time values.

We appreciate your consideration and look forward to hearing your thoughts and feedback.